### PR TITLE
When deleting the cache, unnecessary directories are also deleted.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@ run:
   modules-download-mode: mod
 linters:
   fast: false
-linters-settings:
-  staticcheck:
-    go: 1.16
 issues:
   exclude:
     - SA3000

--- a/diskcache.go
+++ b/diskcache.go
@@ -543,6 +543,37 @@ func (c *DiskCache) removeCache(ci *cacheItem) {
 	}
 }
 
+func (c *DiskCache) recursiveRemoveDir(dir string) error {
+	if c.cacheRoot == dir {
+		return nil
+	}
+	parent := filepath.Dir(dir)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return err
+	}
+	dirs := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs++
+		}
+	}
+	if dirs > 1 {
+		if err := os.RemoveAll(dir); err != nil {
+			return err
+		}
+		return nil
+	}
+	if parent == c.cacheRoot {
+		if err := os.RemoveAll(dir); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return c.recursiveRemoveDir(parent)
+}
+
 func isWritable(dir string) (bool, error) {
 	const tmpFile = "tmpfile"
 	file, err := os.CreateTemp(dir, tmpFile)

--- a/diskcache.go
+++ b/diskcache.go
@@ -557,13 +557,13 @@ func (c *DiskCache) recursiveRemoveDir(dir string) error {
 	for _, e := range entries {
 		if e.IsDir() {
 			dirs++
+			if dirs > 1 {
+				if err := os.RemoveAll(dir); err != nil {
+					return err
+				}
+				return nil
+			}
 		}
-	}
-	if dirs > 1 {
-		if err := os.RemoveAll(dir); err != nil {
-			return err
-		}
-		return nil
 	}
 	if parent == c.cacheRoot {
 		if err := os.RemoveAll(dir); err != nil {

--- a/diskcache.go
+++ b/diskcache.go
@@ -534,6 +534,7 @@ func (c *DiskCache) removeCache(ci *cacheItem) {
 	}()
 	_ = os.Remove(ci.pathkey + reqCacheSuffix) //nostyle:handlerrors
 	_ = os.Remove(ci.pathkey + resCacheSuffix) //nostyle:handlerrors
+	_ = c.recursiveRemoveDir(ci.pathkey)       //nostyle:handlerrors
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.totalBytes < ci.bytes {

--- a/diskcache.go
+++ b/diskcache.go
@@ -558,6 +558,7 @@ func (c *DiskCache) recursiveRemoveDir(dir string) error {
 		if e.IsDir() {
 			dirs++
 			if dirs > 1 {
+				// There are directories beside it, so delete only itself.
 				if err := os.RemoveAll(dir); err != nil {
 					return err
 				}

--- a/diskcache_test.go
+++ b/diskcache_test.go
@@ -291,3 +291,83 @@ func TestDiskCacheStopAll(t *testing.T) {
 	}
 	dc.StopAll()
 }
+
+func TestRecursiveRemoveDir(t *testing.T) {
+	tests := []struct {
+		name   string
+		dirs   []string
+		target string
+		want   []string
+	}{
+		{
+			"single dir",
+			[]string{"a/b/c/d"},
+			"a/b/c/d",
+			nil,
+		},
+		{
+			"multiple dirs",
+			[]string{"a/b/c/d", "a/b/c/e"},
+			"a/b/c/d",
+			[]string{
+				"a",
+				"a/b",
+				"a/b/c",
+				"a/b/c/e",
+			},
+		},
+		{
+			"multiple dirs with different root",
+			[]string{"a/b/c/d", "x/b/c/d"},
+			"a/b/c/d",
+			[]string{
+				"x",
+				"x/b",
+				"x/b/c",
+				"x/b/c/d",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			cacheRoot := filepath.Join(root, "cache")
+			_ = os.RemoveAll(cacheRoot)
+			if err := os.MkdirAll(cacheRoot, 0755); err != nil {
+				t.Fatal(err)
+			}
+			dc, err := NewDiskCache(cacheRoot, 24*time.Hour)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, d := range tt.dirs {
+				if err := os.MkdirAll(filepath.Join(cacheRoot, d), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := dc.recursiveRemoveDir(filepath.Join(cacheRoot, tt.target)); err != nil {
+				t.Error(err)
+			}
+			// read all files
+			var got []string
+			if err := filepath.Walk(cacheRoot, func(path string, info os.FileInfo, err error) error {
+				rel, err := filepath.Rel(cacheRoot, path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if rel == "." {
+					return nil
+				}
+				got = append(got, rel)
+				return nil
+			}); err != nil {
+				t.Error(err)
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/diskcache_test.go
+++ b/diskcache_test.go
@@ -310,9 +310,6 @@ func TestRecursiveRemoveDir(t *testing.T) {
 			[]string{"a/b/c/d", "a/b/c/e"},
 			"a/b/c/d",
 			[]string{
-				"a",
-				"a/b",
-				"a/b/c",
 				"a/b/c/e",
 			},
 		},
@@ -321,9 +318,6 @@ func TestRecursiveRemoveDir(t *testing.T) {
 			[]string{"a/b/c/d", "x/b/c/d"},
 			"a/b/c/d",
 			[]string{
-				"x",
-				"x/b",
-				"x/b/c",
 				"x/b/c/d",
 			},
 		},
@@ -362,6 +356,14 @@ func TestRecursiveRemoveDir(t *testing.T) {
 					t.Fatal(err)
 				}
 				if rel == "." {
+					return nil
+				}
+				// leaf dir only
+				entries, err := os.ReadDir(path)
+				if err != nil {
+					return err
+				}
+				if len(entries) > 0 {
 					return nil
 				}
 				got = append(got, rel)

--- a/diskcache_test.go
+++ b/diskcache_test.go
@@ -333,7 +333,9 @@ func TestRecursiveRemoveDir(t *testing.T) {
 			t.Parallel()
 			root := t.TempDir()
 			cacheRoot := filepath.Join(root, "cache")
-			_ = os.RemoveAll(cacheRoot)
+			if err := os.RemoveAll(cacheRoot); err != nil {
+				t.Fatal(err)
+			}
 			if err := os.MkdirAll(cacheRoot, 0755); err != nil {
 				t.Fatal(err)
 			}
@@ -352,6 +354,9 @@ func TestRecursiveRemoveDir(t *testing.T) {
 			// read all files
 			var got []string
 			if err := filepath.Walk(cacheRoot, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
 				rel, err := filepath.Rel(cacheRoot, path)
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
If directories are not deleted, the host's inodes will be exhausted.

NOTICE: This fix does not delete existing empty cache directories.