### PR TITLE
ci(workflows): update Go version configuration to use `oldstable`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version-file: go.mod
+          go-version: oldstable
 
       - name: Run lint
         uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version-file: go.mod
+          go-version: oldstable
 
       - id: run-tagpr
         name: Run tagpr


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for CI and release tagging to improve Go version management. The main change is switching from using the `go-version-file` input (which reads the Go version from `go.mod`) to explicitly specifying the Go version as `oldstable` in the workflows.

**CI and Workflow Configuration Updates:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL27-R33): Updated the Go setup and related steps to use `go-version: oldstable` instead of `go-version-file: go.mod`, ensuring consistency and explicit Go version selection in the CI pipeline.
* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eL19-R19): Changed the Go setup step to use `go-version: oldstable` for the release tagging workflow, aligning it with the CI workflow and removing reliance on `go.mod` for version selection.