### PR TITLE
fix: stop recursiveRemoveDir from deleting sibling cache files

### DIFF
--- a/diskcache.go
+++ b/diskcache.go
@@ -553,35 +553,21 @@ func (c *DiskCache) removeCache(ci *cacheItem) {
 }
 
 func (c *DiskCache) recursiveRemoveDir(dir string) error {
-	if c.cacheRoot == dir {
-		return nil
-	}
-	parent := filepath.Dir(dir)
-	entries, err := os.ReadDir(parent)
-	if err != nil {
-		return err
-	}
-	dirs := 0
-	for _, e := range entries {
-		if e.IsDir() {
-			dirs++
-			if dirs > 1 {
-				// There are directories beside it, so delete only itself.
-				if err := os.RemoveAll(dir); err != nil {
-					return err
-				}
-				return nil
-			}
+	// Walk upward and remove empty directories only. os.Remove fails on
+	// non-empty directories, which lets sibling cache files (e.g. another
+	// key sharing the same parent) survive. Stop at cacheRoot.
+	for dir != c.cacheRoot {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root without hitting cacheRoot.
+			return nil
 		}
-	}
-	if parent == c.cacheRoot {
-		if err := os.RemoveAll(dir); err != nil {
-			return err
+		if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
+			return nil //nostyle:handlerrors
 		}
-		return nil
+		dir = parent
 	}
-
-	return c.recursiveRemoveDir(parent)
+	return nil
 }
 
 func isWritable(dir string) (bool, error) {

--- a/diskcache.go
+++ b/diskcache.go
@@ -608,8 +608,8 @@ func isDirNotEmpty(err error) bool {
 		return true
 	}
 	if runtime.GOOS == "windows" {
-		var errno syscall.Errno
-		if errors.As(err, &errno) && errno == 145 {
+		var eno syscall.Errno
+		if errors.As(err, &eno) && eno == 145 {
 			return true
 		}
 	}

--- a/diskcache.go
+++ b/diskcache.go
@@ -199,6 +199,13 @@ type cacheItem struct {
 // maxKeys: the maximum number of keys that can be stored in the cache. If NoLimitKeys is specified, there is no limit.
 // maxTotalBytes: the maximum number of bytes that can be stored in the cache. If NoLimitTotalBytes is specified, there is no limit.
 func NewDiskCache(cacheRoot string, defaultTTL time.Duration, opts ...DiskCacheOption) (*DiskCache, error) {
+	// Reject empty input explicitly. filepath.Clean("") returns ".",
+	// which would silently turn an empty argument into the current
+	// working directory and cause cache files to land somewhere the
+	// caller never intended.
+	if cacheRoot == "" {
+		return nil, fmt.Errorf("cache root must not be empty")
+	}
 	// Clean cacheRoot up front so writability checks, stored state, and
 	// the recursiveRemoveDir stop condition all reason about the same
 	// canonical path. Without this, a trailing slash on user input would

--- a/diskcache.go
+++ b/diskcache.go
@@ -199,6 +199,11 @@ type cacheItem struct {
 // maxKeys: the maximum number of keys that can be stored in the cache. If NoLimitKeys is specified, there is no limit.
 // maxTotalBytes: the maximum number of bytes that can be stored in the cache. If NoLimitTotalBytes is specified, there is no limit.
 func NewDiskCache(cacheRoot string, defaultTTL time.Duration, opts ...DiskCacheOption) (*DiskCache, error) {
+	// Clean cacheRoot up front so writability checks, stored state, and
+	// the recursiveRemoveDir stop condition all reason about the same
+	// canonical path. Without this, a trailing slash on user input would
+	// make the stop condition miss cacheRoot.
+	cacheRoot = filepath.Clean(cacheRoot)
 	if ok, err := isWritable(cacheRoot); !ok {
 		return nil, fmt.Errorf("cache root %q is not writable: %w", cacheRoot, err)
 	}
@@ -206,10 +211,7 @@ func NewDiskCache(cacheRoot string, defaultTTL time.Duration, opts ...DiskCacheO
 	warmUpStopCtx, warmUpStopCancelFunc := context.WithCancel(context.Background())
 
 	c := &DiskCache{
-		// Clean cacheRoot so it matches the form produced by filepath.Join
-		// elsewhere. Without this, a trailing slash on user input would
-		// make the recursiveRemoveDir stop condition miss cacheRoot.
-		cacheRoot:            filepath.Clean(cacheRoot),
+		cacheRoot:            cacheRoot,
 		maxKeys:              NoLimitKeys,
 		maxTotalBytes:        NoLimitTotalBytes,
 		cacheDirLen:          DefaultCacheDirLen,

--- a/diskcache.go
+++ b/diskcache.go
@@ -600,10 +600,11 @@ func (c *DiskCache) recursiveRemoveDir(dir string) error {
 }
 
 // isDirNotEmpty reports whether err means "directory not empty".
-// syscall.ENOTEMPTY covers POSIX systems; Windows surfaces the same
-// situation as ERROR_DIR_NOT_EMPTY (winerror.h #145).
+// POSIX (SUSv3) allows rmdir to return either ENOTEMPTY or EEXIST for
+// a non-empty directory, so both are treated the same. Windows
+// surfaces the same situation as ERROR_DIR_NOT_EMPTY (winerror.h #145).
 func isDirNotEmpty(err error) bool {
-	if errors.Is(err, syscall.ENOTEMPTY) {
+	if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
 		return true
 	}
 	if runtime.GOOS == "windows" {

--- a/diskcache.go
+++ b/diskcache.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -205,7 +206,10 @@ func NewDiskCache(cacheRoot string, defaultTTL time.Duration, opts ...DiskCacheO
 	warmUpStopCtx, warmUpStopCancelFunc := context.WithCancel(context.Background())
 
 	c := &DiskCache{
-		cacheRoot:            cacheRoot,
+		// Clean cacheRoot so it matches the form produced by filepath.Join
+		// elsewhere. Without this, a trailing slash on user input would
+		// make the recursiveRemoveDir stop condition miss cacheRoot.
+		cacheRoot:            filepath.Clean(cacheRoot),
 		maxKeys:              NoLimitKeys,
 		maxTotalBytes:        NoLimitTotalBytes,
 		cacheDirLen:          DefaultCacheDirLen,
@@ -583,7 +587,7 @@ func (c *DiskCache) recursiveRemoveDir(dir string) error {
 				dir = parent
 				continue
 			}
-			if errors.Is(err, syscall.ENOTEMPTY) {
+			if isDirNotEmpty(err) {
 				// Raced with a writer that re-populated the dir
 				// between ReadDir and Remove. Normal stop condition.
 				return nil
@@ -593,6 +597,22 @@ func (c *DiskCache) recursiveRemoveDir(dir string) error {
 		dir = parent
 	}
 	return nil
+}
+
+// isDirNotEmpty reports whether err means "directory not empty".
+// syscall.ENOTEMPTY covers POSIX systems; Windows surfaces the same
+// situation as ERROR_DIR_NOT_EMPTY (winerror.h #145).
+func isDirNotEmpty(err error) bool {
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		var errno syscall.Errno
+		if errors.As(err, &errno) && errno == 145 {
+			return true
+		}
+	}
+	return false
 }
 
 func isWritable(dir string) (bool, error) {

--- a/diskcache.go
+++ b/diskcache.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/2manymws/keyrwmutex"
@@ -576,7 +577,17 @@ func (c *DiskCache) recursiveRemoveDir(dir string) error {
 			// Sibling file or directory remains; stop here.
 			return nil
 		}
-		if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(dir); err != nil {
+			if os.IsNotExist(err) {
+				// Raced with another remover; keep walking up.
+				dir = parent
+				continue
+			}
+			if errors.Is(err, syscall.ENOTEMPTY) {
+				// Raced with a writer that re-populated the dir
+				// between ReadDir and Remove. Normal stop condition.
+				return nil
+			}
 			return err
 		}
 		dir = parent

--- a/diskcache.go
+++ b/diskcache.go
@@ -553,17 +553,31 @@ func (c *DiskCache) removeCache(ci *cacheItem) {
 }
 
 func (c *DiskCache) recursiveRemoveDir(dir string) error {
-	// Walk upward and remove empty directories only. os.Remove fails on
-	// non-empty directories, which lets sibling cache files (e.g. another
-	// key sharing the same parent) survive. Stop at cacheRoot.
+	// Walk upward and remove empty directories only. Check emptiness
+	// explicitly with ReadDir so the natural "dir not empty" stop
+	// condition can be distinguished from real IO/permission errors.
+	// Stop at cacheRoot.
 	for dir != c.cacheRoot {
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			// Reached filesystem root without hitting cacheRoot.
 			return nil
 		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// dir is a path stem (or already gone); keep walking up.
+				dir = parent
+				continue
+			}
+			return err
+		}
+		if len(entries) > 0 {
+			// Sibling file or directory remains; stop here.
+			return nil
+		}
 		if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
-			return nil //nostyle:handlerrors
+			return err
 		}
 		dir = parent
 	}

--- a/diskcache_test.go
+++ b/diskcache_test.go
@@ -398,25 +398,28 @@ func TestRecursiveRemoveDirKeepsSiblingFiles(t *testing.T) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	for _, f := range []string{"0.request", "0.response", "1.request", "1.response"} {
-		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0644); err != nil {
-			t.Fatal(err)
+	suffixes := []string{reqCacheSuffix, resCacheSuffix}
+	for _, key := range []string{"0", "1"} {
+		for _, s := range suffixes {
+			if err := os.WriteFile(filepath.Join(dir, key+s), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 
 	// Simulate the production sequence: removeCache deletes the two
 	// files for key "0", then calls recursiveRemoveDir on the stem.
-	if err := os.Remove(filepath.Join(dir, "0.request")); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Remove(filepath.Join(dir, "0.response")); err != nil {
-		t.Fatal(err)
+	for _, s := range suffixes {
+		if err := os.Remove(filepath.Join(dir, "0"+s)); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := dc.recursiveRemoveDir(filepath.Join(dir, "0")); err != nil {
 		t.Errorf("recursiveRemoveDir: %v", err)
 	}
 
-	for _, f := range []string{"1.request", "1.response"} {
+	for _, s := range suffixes {
+		f := "1" + s
 		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
 			t.Errorf("surviving file %s missing: %v", f, err)
 		}

--- a/diskcache_test.go
+++ b/diskcache_test.go
@@ -378,3 +378,50 @@ func TestRecursiveRemoveDir(t *testing.T) {
 		})
 	}
 }
+
+func TestRecursiveRemoveDirKeepsSiblingFiles(t *testing.T) {
+	// Regression: when two cache entries share a parent directory,
+	// evicting one must not delete the surviving entry's files. This
+	// is the scenario that historically surfaced as a flaky CI failure
+	// in TestDiskCacheMaxKeys via the async eviction goroutine.
+	root := t.TempDir()
+	cacheRoot := filepath.Join(root, "cache")
+	if err := os.MkdirAll(cacheRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	dc, err := NewDiskCache(cacheRoot, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(cacheRoot, "a", "b")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"0.request", "0.response", "1.request", "1.response"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Simulate the production sequence: removeCache deletes the two
+	// files for key "0", then calls recursiveRemoveDir on the stem.
+	if err := os.Remove(filepath.Join(dir, "0.request")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(dir, "0.response")); err != nil {
+		t.Fatal(err)
+	}
+	if err := dc.recursiveRemoveDir(filepath.Join(dir, "0")); err != nil {
+		t.Errorf("recursiveRemoveDir: %v", err)
+	}
+
+	for _, f := range []string{"1.request", "1.response"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("surviving file %s missing: %v", f, err)
+		}
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("parent dir removed: %v", err)
+	}
+}

--- a/diskcache_test.go
+++ b/diskcache_test.go
@@ -401,7 +401,7 @@ func TestRecursiveRemoveDirKeepsSiblingFiles(t *testing.T) {
 	suffixes := []string{reqCacheSuffix, resCacheSuffix}
 	for _, key := range []string{"0", "1"} {
 		for _, s := range suffixes {
-			if err := os.WriteFile(filepath.Join(dir, key+s), []byte("x"), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, key+s), []byte("x"), 0600); err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
`TestDiskCacheMaxKeys` was failing on CI (Linux) because evicting one cache entry could wipe out a sibling entry's files.

The old `recursiveRemoveDir` counted only directories in the parent, not files. With two keys sharing the same path stem (e.g. `te/st/0` and `te/st/1`), evicting `test0` walked all the way up to `cacheRoot` and `RemoveAll`'d the entire `te/` subtree, deleting `test1`'s files too. Because `ttlcache.OnEviction` runs in its own goroutine, the race surfaced only on slower schedulers.

This change replaces the heuristic with `os.Remove` walking upward, which only succeeds on empty directories and stops naturally when a sibling file or directory remains.

Failing run: https://github.com/2manymws/rcutil/actions/runs/28413839254